### PR TITLE
FIX: Included FormatInformation script using require()

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -23,7 +23,7 @@
 */
 
 var BitMatrix = require('./bitmat');
-
+var FormatInformation = require('./formatinf');
 
 function ECB(count,  dataCodewords)
 {


### PR DESCRIPTION
**Corrected:**
ReferenceError: FormatInformation is not defined
    at Function.Version.decodeVersionInformation (jsqrcode\src\version.js:203:26)